### PR TITLE
Add build step to package.json for heroku

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "kill": "kill -9 $(lsof -ti tcp:4444)",
     "test:bundle": "cross-env E2E=1 npm run bundle",
     "postinstall": "npm run env",
+    "build": "npm run bundle",
     "husky:install": "cd ../ && husky install",
     "test:bundle:staging": "cross-env E2E=1 ENV=staging npm run bundle",
     "test:dev": "cross-env NODE_ENV=production E2E=true E2E_DEV=true ts-node -T ./e2e/index.cafe",


### PR DESCRIPTION
## Changes [ FT ONLY ]

Add a `build` step to the Frontend `package.json` so that heroku builds the bundle before running the app.
